### PR TITLE
Front End changes for bulk upload

### DIFF
--- a/src/components/DashboardCopy.tsx
+++ b/src/components/DashboardCopy.tsx
@@ -718,7 +718,7 @@ const DashboardCopy = () => {
               type="file"
               ref={fileInputRef}
               onChange={handleFileSelect}
-              accept="image/*"
+              accept=".pdf,image/*"
               className="hidden"
             />
 

--- a/src/components/EventsHome.tsx
+++ b/src/components/EventsHome.tsx
@@ -718,7 +718,7 @@ const DashboardCopy = () => {
               type="file"
               ref={fileInputRef}
               onChange={handleFileSelect}
-              accept="image/*"
+              accept=".pdf,image/*"
               className="hidden"
             />
 

--- a/src/components/ScanFab.tsx
+++ b/src/components/ScanFab.tsx
@@ -266,7 +266,7 @@ const ScanFab = ({ onUploadRequested, isUploadInProgress = false, uploadProgress
         type="file"
         ref={fileInputRef}
         onChange={handleFileSelect}
-        accept="application/pdf,image/*"
+        accept=".pdf,image/*"
         className="hidden"
       />
 

--- a/src/components/card-scanner/UploadPanel.tsx
+++ b/src/components/card-scanner/UploadPanel.tsx
@@ -1,4 +1,3 @@
-
 import { useRef } from 'react';
 import { Camera, Upload } from 'lucide-react';
 import { Button } from "@/components/ui/button";
@@ -44,7 +43,7 @@ const UploadPanel = ({ onCameraStart, onFileUpload }: UploadPanelProps) => {
           type="file"
           ref={fileInputRef}
           onChange={handleFileChange}
-          accept="image/*"
+          accept=".pdf,image/*"
           className="hidden"
         />
       </div>

--- a/src/components/cards/CardTable.tsx
+++ b/src/components/cards/CardTable.tsx
@@ -123,7 +123,7 @@ const CardTable = ({
           type="file"
           ref={fileInputRef}
           onChange={handleFileSelect}
-          accept="image/*"
+          accept=".pdf,image/*"
           className="hidden"
         />
         {Object.keys(rowSelection).length > 0 ? (

--- a/src/components/cardscanner_working.tsx
+++ b/src/components/cardscanner_working.tsx
@@ -79,8 +79,14 @@ const CardScanner = ({ initialMode }: CardScannerProps) => {
       }, 300);
   
       try {
-        // Send the image to the backend
-        const response = await authFetch("http://localhost:8000/upload", {
+        // Determine endpoint based on file type
+        let endpoint = "/upload";
+        if (file.type === "application/pdf" || file.name.toLowerCase().endsWith('.pdf')) {
+          endpoint = "/bulk-upload";
+        }
+        const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+        // Send the image or PDF to the backend
+        const response = await authFetch(`${apiBaseUrl}${endpoint}`, {
           method: "POST",
           body: formData,
         });

--- a/src/hooks/useCardUpload.ts
+++ b/src/hooks/useCardUpload.ts
@@ -19,7 +19,11 @@ export const useCardUpload = () => {
       formData.append("school_id", schoolId);
       
       const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
-      const response = await authFetch(`${apiBaseUrl}/upload`, {
+      let endpoint = "/upload";
+      if (file.type === "application/pdf" || file.name.toLowerCase().endsWith('.pdf')) {
+        endpoint = "/bulk-upload";
+      }
+      const response = await authFetch(`${apiBaseUrl}${endpoint}`, {
         method: 'POST',
         body: formData
       }, session?.access_token);

--- a/src/pages/ScanPage.tsx
+++ b/src/pages/ScanPage.tsx
@@ -456,10 +456,9 @@ const ScanPage: React.FC = () => {
         {useFileInput && (
           <input
             type="file"
-            accept="image/*"
-            capture="environment"
-            onChange={handleFileChange}
             ref={fileInputRef}
+            onChange={handleFileChange}
+            accept=".pdf,image/*"
             className="hidden"
           />
         )}
@@ -630,10 +629,9 @@ const ScanPage: React.FC = () => {
                 <input
                   type="file"
                   ref={fileInputRef}
-                  className="hidden"
-                  accept="image/*"
-                  capture="environment"
                   onChange={handleFileChange}
+                  accept=".pdf,image/*"
+                  className="hidden"
                 />
               )}
             </div>

--- a/supabase/migrations/20240608_add_docai_processor_id_to_schools.sql
+++ b/supabase/migrations/20240608_add_docai_processor_id_to_schools.sql
@@ -1,0 +1,10 @@
+-- Add docai_processor_id column to public.schools if it doesn't exist
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='schools' AND column_name='docai_processor_id'
+  ) THEN
+    ALTER TABLE public.schools ADD COLUMN docai_processor_id TEXT;
+  END IF;
+END $$; 


### PR DESCRIPTION
Front end changes for bulk upload

- Changed the 'add file' cta to accept images or pdfs
- If a PDF is received front end calls the new /bulk-upload endpoint
- PDF is stripped into individual cards, converted to PNGs, stored in supabase storage and a row is written to processing_jobs where the worker will pick up each row 